### PR TITLE
Allow all interface names to be passed in (not just 'monX')

### DIFF
--- a/watcher.py
+++ b/watcher.py
@@ -29,9 +29,6 @@ def ValidInterface():
 	avail = False
 	wlan = stores.args.interface
 	if stores.args.verbose: print 'Looking for: ' + wlan
-	if not "mon" in wlan:
-		print 'You must select a monitor interface (ie. mon0, mon1, etc).'
-		return
 	if stores.args.verbose: print 'Verifying wireless interface is available...'
 	s=cli.execute_shell('ifconfig | grep ' + wlan)
 	lines = s.splitlines()


### PR DESCRIPTION
Any interface name can now be passed in. Watcher no longer requires the name of the interface in monitor mode to be 'monX' (e.g. - mon0, mon1, mon2).